### PR TITLE
Check out codes at pull request head

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
This event runs in the context of the base of the pull request, rather than in the merge commit as the pull_request event does.  So we should specify the ref and repository of the PR in the checkout action.
Signed-off-by: zhaohuabing <huabingzhao@tencent.com>