### PR TITLE
set workloadselector for inbound envoy filter

### DIFF
--- a/pkg/envoyfilter/network_filter_test.go
+++ b/pkg/envoyfilter/network_filter_test.go
@@ -1,0 +1,60 @@
+package envoyfilter
+
+import (
+	"reflect"
+	"testing"
+
+	istioconfig "istio.io/istio/pkg/config"
+
+	"github.com/aeraki-framework/aeraki/pkg/model"
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+func Test_inboudEnvoyFilterWorkloadSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *model.ServiceEntryWrapper
+		want    *networking.WorkloadSelector
+	}{
+		{
+			name: "test1",
+			service: &model.ServiceEntryWrapper{
+				Spec: &networking.ServiceEntry{
+					WorkloadSelector: &networking.WorkloadSelector{
+						Labels: map[string]string{
+							"app": "dubbo-sample-provider",
+						},
+					},
+				},
+			},
+			want: &networking.WorkloadSelector{
+				Labels: map[string]string{
+					"app": "dubbo-sample-provider",
+				},
+			},
+		},
+		{
+			name: "test2",
+			service: &model.ServiceEntryWrapper{
+				Meta: istioconfig.Meta{
+					Annotations: map[string]string{
+						"workloadSelector": "dubbo-sample-provider",
+					},
+				},
+				Spec: &networking.ServiceEntry{},
+			},
+			want: &networking.WorkloadSelector{
+				Labels: map[string]string{
+					"app": "dubbo-sample-provider",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inboudEnvoyFilterWorkloadSelector(tt.service); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("inboudEnvoyFilterWorkloadSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/dubbo/generator.go
+++ b/plugin/dubbo/generator.go
@@ -34,7 +34,7 @@ func NewGenerator() *Generator {
 // Generate create EnvoyFilters for Dubbo services
 func (*Generator) Generate(context *model.EnvoyFilterContext) []*model.EnvoyFilterWrapper {
 	return envoyfilter.GenerateReplaceNetworkFilter(
-		context.ServiceEntry.Spec,
+		context.ServiceEntry,
 		buildOutboundProxy(context),
 		buildInboundProxy(context),
 		"envoy.filters.network.dubbo_proxy",

--- a/plugin/kafka/generator.go
+++ b/plugin/kafka/generator.go
@@ -31,7 +31,7 @@ func NewGenerator() *Generator {
 // Generate create EnvoyFilters for Dubbo services
 func (*Generator) Generate(context *model.EnvoyFilterContext) []*model.EnvoyFilterWrapper {
 	return envoyfilter.GenerateInsertBeforeNetworkFilter(
-		context.ServiceEntry.Spec,
+		context.ServiceEntry,
 		buildOutboundProxy(context),
 		buildInboundProxy(context),
 		"envoy.filters.network.kafka_broker",

--- a/plugin/redis/generator.go
+++ b/plugin/redis/generator.go
@@ -84,7 +84,7 @@ func (g *Generator) generate(ctx context.Context, filterContext *model.EnvoyFilt
 	spec := *filterContext.ServiceEntry.Spec
 	spec.Ports = []*networking.Port{targetPort}
 	filters := envoyfilter.GenerateReplaceNetworkFilter(
-		&spec,
+		filterContext.ServiceEntry,
 		g.buildOutboundProxyWithFallback(ctx, filterContext, port, portName),
 		g.buildInboundProxy(filterContext, port, portName),
 		"envoy.filters.network.redis_proxy",

--- a/plugin/thrift/generator.go
+++ b/plugin/thrift/generator.go
@@ -34,7 +34,7 @@ func NewGenerator() *Generator {
 // Generate create EnvoyFilters for Dubbo services
 func (*Generator) Generate(context *model.EnvoyFilterContext) []*model.EnvoyFilterWrapper {
 	return envoyfilter.GenerateReplaceNetworkFilter(
-		context.ServiceEntry.Spec,
+		context.ServiceEntry,
 		buildOutboundProxy(context),
 		buildInboundProxy(context),
 		"envoy.filters.network.thrift_proxy",

--- a/plugin/zookeeper/generator.go
+++ b/plugin/zookeeper/generator.go
@@ -31,7 +31,7 @@ func NewGenerator() *Generator {
 // Generate create EnvoyFilters for Dubbo services
 func (*Generator) Generate(context *model.EnvoyFilterContext) []*model.EnvoyFilterWrapper {
 	return envoyfilter.GenerateInsertBeforeNetworkFilter(
-		context.ServiceEntry.Spec,
+		context.ServiceEntry,
 		buildOutboundProxy(context),
 		buildInboundProxy(context),
 		"envoy.filters.network.zookeeper_proxy",

--- a/test/e2e/dubbo/dubbo_test.go
+++ b/test/e2e/dubbo/dubbo_test.go
@@ -40,10 +40,10 @@ func setup() {
 }
 
 func shutdown() {
-	//util.KubeDelete("dubbo", "testdata/dubbo-sample.yaml", "")
-	//util.KubeDelete("dubbo", "testdata/serviceentry.yaml", "")
-	//util.KubeDelete("dubbo", "testdata/destinationrule.yaml", "")
-	//util.DeleteNamespace("dubbo", "")
+	util.KubeDelete("dubbo", "testdata/dubbo-sample.yaml", "")
+	util.KubeDelete("dubbo", "testdata/serviceentry.yaml", "")
+	util.KubeDelete("dubbo", "testdata/destinationrule.yaml", "")
+	util.DeleteNamespace("dubbo", "")
 }
 
 func TestSidecarOutboundConfig(t *testing.T) {


### PR DESCRIPTION
workloadselector should be set for inbound envoy filters to avoid
override inbound config of other services at the same port

Signed-off-by: zhaohuabing <huabingzhao@tencent.com>