### PR TITLE
Add Dubbo Authorizatio Ploicy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ style-check:
 	goimports -l -d ./
 lint:
 	golint ./...
+	golangci-lint run --tests="false"
 e2e-dubbo:
 	go test -v github.com/aeraki-framework/aeraki/test/e2e/dubbo/...
 e2e-thrift:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Similar to Istio, protocols are identified by service port prefix. Please name s
   * [x] Metrics
   * [x] Method based routing
   * [ ] Header based routing
-  * [ ] Peer authorization on Interface/Method (Wok in Progress)
+  * [x] Peer authorization on Interface/Method
 * Thrift
   * [x] Default routing
   * [x] Version-based routing

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Similar to Istio, protocols are identified by service port prefix. Please name s
 
 ## Supported protocols:
 * Dubbo
+  * [x] ZooKeeper registry
   * [x] Default routing
   * [x] Version-based routing
   * [x] Traffic splitting

--- a/api/dubbo/v1alpha1/dubbo_authorization_policy.pb.go
+++ b/api/dubbo/v1alpha1/dubbo_authorization_policy.pb.go
@@ -12,11 +12,12 @@ package v1alpha1
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
-	_ "istio.io/gogo-genproto/googleapis/google/api"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	_ "istio.io/gogo-genproto/googleapis/google/api"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -68,7 +69,7 @@ func (DubboAuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:DubboAuthorizationPolicy:labels:app=aeraki,chart=aeraki,heritage=Tiller,release=aeraki
 // +cue-gen:DubboAuthorizationPolicy:subresource:status
 // +cue-gen:DubboAuthorizationPolicy:scope:Namespaced
-// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,shortNames=dap
+// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,plural=dubboauthorizationpolicies,shortNames=dap
 // +cue-gen:DubboAuthorizationPolicy:preserveUnknownFields:false
 // -->
 //

--- a/api/dubbo/v1alpha1/dubbo_authorization_policy.proto
+++ b/api/dubbo/v1alpha1/dubbo_authorization_policy.proto
@@ -105,7 +105,7 @@ option go_package = "github.com/aeraki-framework/aeraki/api/dubbo/v1alpha1";
 // +cue-gen:DubboAuthorizationPolicy:labels:app=aeraki,chart=aeraki,heritage=Tiller,release=aeraki
 // +cue-gen:DubboAuthorizationPolicy:subresource:status
 // +cue-gen:DubboAuthorizationPolicy:scope:Namespaced
-// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,shortNames=dap
+// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,plural=dubboauthorizationpolicies,shortNames=dap
 // +cue-gen:DubboAuthorizationPolicy:preserveUnknownFields:false
 // -->
 //

--- a/api/dubbo/v1alpha1/dubbo_authorization_policy_deepcopy.gen.go
+++ b/api/dubbo/v1alpha1/dubbo_authorization_policy_deepcopy.gen.go
@@ -12,9 +12,10 @@ package v1alpha1
 
 import (
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/gogo/protobuf/proto"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/dubbo/v1alpha1/dubbo_authorization_policy_json.gen.go
+++ b/api/dubbo/v1alpha1/dubbo_authorization_policy_json.gen.go
@@ -13,10 +13,11 @@ package v1alpha1
 import (
 	bytes "bytes"
 	fmt "fmt"
+	math "math"
+
 	github_com_gogo_protobuf_jsonpb "github.com/gogo/protobuf/jsonpb"
 	proto "github.com/gogo/protobuf/proto"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisdestination.pb.go
+++ b/api/redis/v1alpha1/redisdestination.pb.go
@@ -7,13 +7,14 @@ package v1alpha1
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	_ "github.com/gogo/protobuf/types"
 	io "io"
-	v1alpha3 "istio.io/api/networking/v1alpha3"
-	_ "istio.io/gogo-genproto/googleapis/google/api"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/gogo/protobuf/types"
+	v1alpha3 "istio.io/api/networking/v1alpha3"
+	_ "istio.io/gogo-genproto/googleapis/google/api"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisdestination_deepcopy.gen.go
+++ b/api/redis/v1alpha1/redisdestination_deepcopy.gen.go
@@ -7,11 +7,12 @@ package v1alpha1
 
 import (
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	_ "istio.io/api/networking/v1alpha3"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisdestination_json.gen.go
+++ b/api/redis/v1alpha1/redisdestination_json.gen.go
@@ -8,12 +8,13 @@ package v1alpha1
 import (
 	bytes "bytes"
 	fmt "fmt"
+	math "math"
+
 	github_com_gogo_protobuf_jsonpb "github.com/gogo/protobuf/jsonpb"
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	_ "istio.io/api/networking/v1alpha3"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisservice.pb.go
+++ b/api/redis/v1alpha1/redisservice.pb.go
@@ -8,12 +8,13 @@ package v1alpha1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	types "github.com/gogo/protobuf/types"
 	io "io"
-	_ "istio.io/gogo-genproto/googleapis/google/api"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	types "github.com/gogo/protobuf/types"
+	_ "istio.io/gogo-genproto/googleapis/google/api"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisservice_deepcopy.gen.go
+++ b/api/redis/v1alpha1/redisservice_deepcopy.gen.go
@@ -7,10 +7,11 @@ package v1alpha1
 
 import (
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/api/redis/v1alpha1/redisservice_json.gen.go
+++ b/api/redis/v1alpha1/redisservice_json.gen.go
@@ -8,11 +8,12 @@ package v1alpha1
 import (
 	bytes "bytes"
 	fmt "fmt"
+	math "math"
+
 	github_com_gogo_protobuf_jsonpb "github.com/gogo/protobuf/jsonpb"
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	_ "istio.io/gogo-genproto/googleapis/google/api"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/client-go/pkg/apis/dubbo/v1alpha1/types.gen.go
+++ b/client-go/pkg/apis/dubbo/v1alpha1/types.gen.go
@@ -37,7 +37,7 @@ import (
 // +cue-gen:DubboAuthorizationPolicy:labels:app=aeraki,chart=aeraki,heritage=Tiller,release=aeraki
 // +cue-gen:DubboAuthorizationPolicy:subresource:status
 // +cue-gen:DubboAuthorizationPolicy:scope:Namespaced
-// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,shortNames=dap
+// +cue-gen:DubboAuthorizationPolicy:resource:categories=aeraki-io,dubbo-aeraki-io,plural=dubboauthorizationpolicies,shortNames=dap
 // +cue-gen:DubboAuthorizationPolicy:preserveUnknownFields:false
 // -->
 //

--- a/cmd/aeraki/main.go
+++ b/cmd/aeraki/main.go
@@ -22,7 +22,6 @@ import (
 	"syscall"
 
 	"github.com/aeraki-framework/aeraki/pkg/envoyfilter"
-	"github.com/aeraki-framework/aeraki/plugin/dubbo"
 	"github.com/aeraki-framework/aeraki/plugin/kafka"
 	"github.com/aeraki-framework/aeraki/plugin/thrift"
 	"github.com/aeraki-framework/aeraki/plugin/zookeeper"
@@ -67,7 +66,6 @@ func main() {
 
 func initGenerators() map[protocol.Instance]envoyfilter.Generator {
 	return map[protocol.Instance]envoyfilter.Generator{
-		protocol.Dubbo:     dubbo.NewGenerator(),
 		protocol.Thrift:    thrift.NewGenerator(),
 		protocol.Kafka:     kafka.NewGenerator(),
 		protocol.Zookeeper: zookeeper.NewGenerator(),

--- a/crd/kubernetes/customresourcedefinitions.gen.yaml
+++ b/crd/kubernetes/customresourcedefinitions.gen.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: aeraki
     heritage: Tiller
     release: aeraki
-  name: dubboauthorizationpolicys.dubbo.aeraki.io
+  name: dubboauthorizationpolicies.dubbo.aeraki.io
 spec:
   group: dubbo.aeraki.io
   names:
@@ -18,7 +18,7 @@ spec:
     - dubbo-aeraki-io
     kind: DubboAuthorizationPolicy
     listKind: DubboAuthorizationPolicyList
-    plural: dubboauthorizationpolicys
+    plural: dubboauthorizationpolicies
     shortNames:
     - dap
     singular: dubboauthorizationpolicy

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20210115003313-31f9241a16e6
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/aeraki-framework/aeraki/plugin/dubbo"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -76,6 +78,7 @@ func NewServer(args *AerakiArgs) (*Server, error) {
 	})
 
 	cfg := crdController.GetConfig()
+	args.Protocols[protocol.Dubbo] = dubbo.NewGenerator(cfg)
 	args.Protocols[protocol.Redis] = redis.New(cfg, configController.Store)
 
 	configController.RegisterEventHandler(args.Protocols, func(_, curr istioconfig.Config, event model.Event) {

--- a/pkg/kube/controller/controller.go
+++ b/pkg/kube/controller/controller.go
@@ -21,18 +21,19 @@ func NewManager(kubeConfig *rest.Config, namespace string, electionID string,
 	m, err := manager.New(kubeConfig, mgrOpt)
 	if err != nil {
 		controllerLog.Fatalf("Could not create a controller manager: %v", err)
-		return nil
 	}
 
 	err = addRedisServiceController(m, triggerPush)
 	if err != nil {
 		controllerLog.Fatalf("Could not add RedisServiceController: %e", err)
-		return nil
 	}
 	err = addRedisDestinationController(m, triggerPush)
 	if err != nil {
 		controllerLog.Fatalf("Could not add RedisDestinationController: %e", err)
-		return nil
+	}
+	err = addDubboAuthorizationPolicyController(m, triggerPush)
+	if err != nil {
+		controllerLog.Fatalf("Could not add DubboAuthorizationPolicyController: %e", err)
 	}
 	err = scheme.AddToScheme(m.GetScheme())
 	if err != nil {

--- a/plugin/dubbo/authz/builder/builder.go
+++ b/plugin/dubbo/authz/builder/builder.go
@@ -1,0 +1,146 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"context"
+	"fmt"
+
+	dubborulepb "github.com/aeraki-framework/aeraki/api/dubbo/v1alpha1"
+	dubboapi "github.com/aeraki-framework/aeraki/client-go/pkg/apis/dubbo/v1alpha1"
+	dubboclient "github.com/aeraki-framework/aeraki/client-go/pkg/clientset/versioned/typed/dubbo/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	dubbopb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/dubbo_proxy/v3"
+	rbacdubbopb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
+	"github.com/golang/protobuf/ptypes"
+
+	authzmodel "github.com/aeraki-framework/aeraki/plugin/dubbo/authz/model"
+	"istio.io/istio/pilot/pkg/security/trustdomain"
+	"istio.io/pkg/log"
+)
+
+var (
+	authzLog = log.RegisterScope("authorization", "Aeraki Dubbo Authorization Policy", 0)
+)
+
+// Builder builds Istio authorization policy to Envoy RBAC filter.
+type Builder struct {
+	trustDomainBundle trustdomain.Bundle
+	denyPolicies      []dubboapi.DubboAuthorizationPolicy
+	allowPolicies     []dubboapi.DubboAuthorizationPolicy
+}
+
+// New returns a new builder for the given workload with the authorization policy.
+// Returns nil if none of the authorization policies are enabled for the workload.
+func New(trustDomainBundle trustdomain.Bundle, namespace string,
+	client dubboclient.DubboV1alpha1Interface) *Builder {
+	allowPolicies := make([]dubboapi.DubboAuthorizationPolicy, 0)
+	denyPolicies := make([]dubboapi.DubboAuthorizationPolicy, 0)
+
+	dubboAuthorizationPolicyList, err := client.DubboAuthorizationPolicies(namespace).List(context.TODO(),
+		v1.ListOptions{})
+	if err != nil {
+		authzLog.Errorf("failed to list DubboAuthorizationPolicy: %v", err)
+	} else {
+		for _, config := range dubboAuthorizationPolicyList.Items {
+			switch config.Spec.GetAction() {
+			case dubborulepb.DubboAuthorizationPolicy_ALLOW:
+				allowPolicies = append(allowPolicies, config)
+			case dubborulepb.DubboAuthorizationPolicy_DENY:
+				denyPolicies = append(denyPolicies, config)
+			default:
+				log.Errorf("ignored authorization policy %s.%s with unsupported action: %s",
+					config.Namespace, config.Name, config.Spec.GetAction())
+			}
+		}
+	}
+
+	return &Builder{
+		trustDomainBundle: trustDomainBundle,
+		denyPolicies:      denyPolicies,
+		allowPolicies:     allowPolicies,
+	}
+}
+
+// BuildDubboFilter returns the RBAC TCP filters built from the authorization policy.
+func (b Builder) BuildDubboFilter() []*dubbopb.DubboFilter {
+	filters := make([]*dubbopb.DubboFilter, 0)
+
+	if denyConfig := build(b.denyPolicies, b.trustDomainBundle, rbacpb.RBAC_DENY); denyConfig != nil {
+		filters = append(filters, createDubboRBACFilter(denyConfig))
+	}
+	if allowConfig := build(b.allowPolicies, b.trustDomainBundle, rbacpb.RBAC_ALLOW); allowConfig != nil {
+		filters = append(filters, createDubboRBACFilter(allowConfig))
+	}
+
+	return filters
+}
+
+func build(policies []dubboapi.DubboAuthorizationPolicy, tdBundle trustdomain.Bundle,
+	action rbacpb.RBAC_Action) *rbacpb.RBAC {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	rules := &rbacpb.RBAC{
+		Action:   action,
+		Policies: map[string]*rbacpb.Policy{},
+	}
+
+	for _, policy := range policies {
+		for i, rule := range policy.Spec.Rules {
+			name := fmt.Sprintf("ns[%s]-policy[%s]-rule[%d]", policy.Namespace, policy.Name, i)
+			if rule == nil {
+				authzLog.Errorf("skipped nil rule %s", name)
+				continue
+			}
+			m, err := authzmodel.New(rule)
+			if err != nil {
+				authzLog.Errorf("skipped rule %s: %v", name, err)
+				continue
+			}
+			m.MigrateTrustDomain(tdBundle)
+			generated, err := m.Generate(action)
+			if err != nil {
+				authzLog.Errorf("skipped rule %s: %v", name, err)
+				continue
+			}
+			if generated != nil {
+				rules.Policies[name] = generated
+				authzLog.Debugf("rule %s generated policy: %+v", name, generated)
+			}
+		}
+	}
+
+	return rules
+}
+
+func createDubboRBACFilter(config *rbacpb.RBAC) *dubbopb.DubboFilter {
+	if config == nil {
+		return nil
+	}
+
+	rbacConfig := &rbacdubbopb.RBAC{
+		Rules:      config,
+		StatPrefix: authzmodel.RBACDubboFilterStatPrefix,
+	}
+	rbacPolicyInAny, _ := ptypes.MarshalAny(rbacConfig)
+	return &dubbopb.DubboFilter{
+		Name:   authzmodel.RBACDUBBOFilterName,
+		Config: rbacPolicyInAny,
+	}
+}

--- a/plugin/dubbo/authz/matcher/cidr.go
+++ b/plugin/dubbo/authz/matcher/cidr.go
@@ -1,0 +1,60 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/golang/protobuf/ptypes/wrappers"
+)
+
+// CidrRange converts a CIDR or a single IP string to a corresponding CidrRange. For a single IP
+// string the converted CidrRange prefix is either 32 (for ipv4) or 128 (for ipv6).
+func CidrRange(v string) (*corepb.CidrRange, error) {
+	var address string
+	var prefixLen int
+
+	if strings.Contains(v, "/") {
+		if ip, ipnet, err := net.ParseCIDR(v); err == nil {
+			address = ip.String()
+			prefixLen, _ = ipnet.Mask.Size()
+		} else {
+			return nil, fmt.Errorf("invalid cidr range: %v", err)
+		}
+	} else {
+		if ip := net.ParseIP(v); ip != nil {
+			address = ip.String()
+			if strings.Contains(v, ".") {
+				// Set the prefixLen to 32 for ipv4 address.
+				prefixLen = 32
+			} else if strings.Contains(v, ":") {
+				// Set the prefixLen to 128 for ipv6 address.
+				prefixLen = 128
+			} else {
+				return nil, fmt.Errorf("invalid ip address: %s", v)
+			}
+		} else {
+			return nil, fmt.Errorf("invalid ip address: %s", v)
+		}
+	}
+
+	return &corepb.CidrRange{
+		AddressPrefix: address,
+		PrefixLen:     &wrappers.UInt32Value{Value: uint32(prefixLen)},
+	}, nil
+}

--- a/plugin/dubbo/authz/matcher/cidr_test.go
+++ b/plugin/dubbo/authz/matcher/cidr_test.go
@@ -1,0 +1,92 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"strings"
+	"testing"
+
+	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestCidrRange(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		V      string
+		Expect *corepb.CidrRange
+		Err    string
+	}{
+		{
+			Name: "cidr with two /",
+			V:    "192.168.0.0//16",
+			Err:  "invalid cidr range",
+		},
+		{
+			Name: "cidr with invalid prefix length",
+			V:    "192.168.0.0/ab",
+			Err:  "invalid cidr range",
+		},
+		{
+			Name: "cidr with negative prefix length",
+			V:    "192.168.0.0/-16",
+			Err:  "invalid cidr range",
+		},
+		{
+			Name: "valid cidr range",
+			V:    "192.168.0.0/16",
+			Expect: &corepb.CidrRange{
+				AddressPrefix: "192.168.0.0",
+				PrefixLen:     &wrappers.UInt32Value{Value: 16},
+			},
+		},
+		{
+			Name: "invalid ip address",
+			V:    "19216800",
+			Err:  "invalid ip address",
+		},
+		{
+			Name: "valid ipv4 address",
+			V:    "192.168.0.0",
+			Expect: &corepb.CidrRange{
+				AddressPrefix: "192.168.0.0",
+				PrefixLen:     &wrappers.UInt32Value{Value: 32},
+			},
+		},
+		{
+			Name: "valid ipv6 address",
+			V:    "2001:abcd:85a3::8a2e:370:1234",
+			Expect: &corepb.CidrRange{
+				AddressPrefix: "2001:abcd:85a3::8a2e:370:1234",
+				PrefixLen:     &wrappers.UInt32Value{Value: 128},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual, err := CidrRange(tc.V)
+		if tc.Err != "" {
+			if err == nil {
+				t.Errorf("%s: expecting error: %s but found no error", tc.Name, tc.Err)
+			} else if !strings.HasPrefix(err.Error(), tc.Err) {
+				t.Errorf("%s: expecting error: %s, but got: %s", tc.Name, tc.Err, err.Error())
+			}
+		} else if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+			t.Errorf("%s: expecting %v, but got %v", tc.Name, tc.Expect, actual)
+		}
+	}
+}

--- a/plugin/dubbo/authz/matcher/header.go
+++ b/plugin/dubbo/authz/matcher/header.go
@@ -1,0 +1,65 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"strings"
+
+	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+// HeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.
+func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
+	// We must check "*" first to make sure we'll generate a non empty value in the prefix/suffix case.
+	// Empty prefix/suffix value is invalid in HeaderMatcher.
+	if v == "*" {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
+				PresentMatch: true,
+			},
+		}
+	} else if strings.HasPrefix(v, "*") {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
+				SuffixMatch: v[1:],
+			},
+		}
+	} else if strings.HasSuffix(v, "*") {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
+				PrefixMatch: v[:len(v)-1],
+			},
+		}
+	}
+	return &routepb.HeaderMatcher{
+		Name: k,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
+			ExactMatch: v,
+		},
+	}
+}
+
+// PathMatcher creates a path matcher for a path.
+func PathMatcher(path string) *matcherpb.PathMatcher {
+	return &matcherpb.PathMatcher{
+		Rule: &matcherpb.PathMatcher_Path{
+			Path: StringMatcher(path),
+		},
+	}
+}

--- a/plugin/dubbo/authz/matcher/header_test.go
+++ b/plugin/dubbo/authz/matcher/header_test.go
@@ -1,0 +1,138 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestHeaderMatcher(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		K      string
+		V      string
+		Expect *routepb.HeaderMatcher
+	}{
+		{
+			Name: "exact match",
+			K:    ":path",
+			V:    "/productpage",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
+					ExactMatch: "/productpage",
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			K:    ":path",
+			V:    "*/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
+					SuffixMatch: "/productpage*",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := HeaderMatcher(tc.K, tc.V)
+		if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+			t.Errorf("expecting %v, but got %v", tc.Expect, actual)
+		}
+	}
+}
+
+func TestPathMatcher(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		V      string
+		Expect *matcherpb.PathMatcher
+	}{
+		{
+			Name: "exact match",
+			V:    "/productpage",
+			Expect: &matcherpb.PathMatcher{
+				Rule: &matcherpb.PathMatcher_Path{
+					Path: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Exact{
+							Exact: "/productpage",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match",
+			V:    "/prefix*",
+			Expect: &matcherpb.PathMatcher{
+				Rule: &matcherpb.PathMatcher_Path{
+					Path: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Prefix{
+							Prefix: "/prefix",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			V:    "*suffix",
+			Expect: &matcherpb.PathMatcher{
+				Rule: &matcherpb.PathMatcher_Path{
+					Path: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_Suffix{
+							Suffix: "suffix",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "wildcard match",
+			V:    "*",
+			Expect: &matcherpb.PathMatcher{
+				Rule: &matcherpb.PathMatcher_Path{
+					Path: &matcherpb.StringMatcher{
+						MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+							SafeRegex: &matcherpb.RegexMatcher{
+								Regex: ".+",
+								EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+									GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual := PathMatcher(tc.V)
+			if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+				t.Errorf("expecting %v, but got %v", tc.Expect, actual)
+			}
+		})
+	}
+}

--- a/plugin/dubbo/authz/matcher/metadata.go
+++ b/plugin/dubbo/authz/matcher/metadata.go
@@ -1,0 +1,71 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+// MetadataStringMatcher creates a metadata string matcher for the given filter, key and the
+// string matcher.
+func MetadataStringMatcher(filter, key string, m *matcherpb.StringMatcher) *matcherpb.MetadataMatcher {
+	return &matcherpb.MetadataMatcher{
+		Filter: filter,
+		Path: []*matcherpb.MetadataMatcher_PathSegment{
+			{
+				Segment: &matcherpb.MetadataMatcher_PathSegment_Key{
+					Key: key,
+				},
+			},
+		},
+		Value: &matcherpb.ValueMatcher{
+			MatchPattern: &matcherpb.ValueMatcher_StringMatch{
+				StringMatch: m,
+			},
+		},
+	}
+}
+
+// MetadataListMatcher creates a metadata list matcher for the given path keys and value.
+func MetadataListMatcher(filter string, keys []string, value string) *matcherpb.MetadataMatcher {
+	listMatcher := &matcherpb.ListMatcher{
+		MatchPattern: &matcherpb.ListMatcher_OneOf{
+			OneOf: &matcherpb.ValueMatcher{
+				MatchPattern: &matcherpb.ValueMatcher_StringMatch{
+					StringMatch: StringMatcher(value),
+				},
+			},
+		},
+	}
+
+	paths := make([]*matcherpb.MetadataMatcher_PathSegment, 0)
+	for _, k := range keys {
+		paths = append(paths, &matcherpb.MetadataMatcher_PathSegment{
+			Segment: &matcherpb.MetadataMatcher_PathSegment_Key{
+				Key: k,
+			},
+		})
+	}
+
+	return &matcherpb.MetadataMatcher{
+		Filter: filter,
+		Path:   paths,
+		Value: &matcherpb.ValueMatcher{
+			MatchPattern: &matcherpb.ValueMatcher_ListMatch{
+				ListMatch: listMatcher,
+			},
+		},
+	}
+}

--- a/plugin/dubbo/authz/matcher/metadata_test.go
+++ b/plugin/dubbo/authz/matcher/metadata_test.go
@@ -1,0 +1,112 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestMetadataStringMatcher(t *testing.T) {
+	matcher := &matcherpb.StringMatcher{
+		MatchPattern: &matcherpb.StringMatcher_Exact{
+			Exact: "exact",
+		},
+	}
+	actual := MetadataStringMatcher("istio_authn", "key", matcher)
+	expect := &matcherpb.MetadataMatcher{
+		Filter: "istio_authn",
+		Path: []*matcherpb.MetadataMatcher_PathSegment{
+			{
+				Segment: &matcherpb.MetadataMatcher_PathSegment_Key{
+					Key: "key",
+				},
+			},
+		},
+		Value: &matcherpb.ValueMatcher{
+			MatchPattern: &matcherpb.ValueMatcher_StringMatch{
+				StringMatch: matcher,
+			},
+		},
+	}
+
+	if !cmp.Equal(actual, expect, protocmp.Transform()) {
+		t.Errorf("want %s, got %s", expect.String(), actual.String())
+	}
+}
+
+func TestMetadataListMatcher(t *testing.T) {
+	getWant := func(regex string) *matcherpb.MetadataMatcher {
+		return &matcherpb.MetadataMatcher{
+			Filter: "istio_authn",
+			Path: []*matcherpb.MetadataMatcher_PathSegment{
+				{
+					Segment: &matcherpb.MetadataMatcher_PathSegment_Key{
+						Key: "key1",
+					},
+				},
+				{
+					Segment: &matcherpb.MetadataMatcher_PathSegment_Key{
+						Key: "key2",
+					},
+				},
+			},
+			Value: &matcherpb.ValueMatcher{
+				MatchPattern: &matcherpb.ValueMatcher_ListMatch{
+					ListMatch: &matcherpb.ListMatcher{
+						MatchPattern: &matcherpb.ListMatcher_OneOf{
+							OneOf: &matcherpb.ValueMatcher{
+								MatchPattern: &matcherpb.ValueMatcher_StringMatch{
+									StringMatch: &matcherpb.StringMatcher{
+										MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+											SafeRegex: &matcherpb.RegexMatcher{
+												EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+													GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+												},
+												Regex: regex,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "wildcard",
+			want: ".+",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := getWant(tc.want)
+			actual := MetadataListMatcher("istio_authn", []string{"key1", "key2"}, "*")
+			if !cmp.Equal(want, actual, protocmp.Transform()) {
+				t.Errorf("want %s, but got %s", want.String(), actual.String())
+			}
+		})
+	}
+}

--- a/plugin/dubbo/authz/matcher/string.go
+++ b/plugin/dubbo/authz/matcher/string.go
@@ -1,0 +1,73 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"strings"
+
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+// StringMatcher creates a string matcher for v.
+func StringMatcher(v string) *matcherpb.StringMatcher {
+	return StringMatcherWithPrefix(v, "")
+}
+
+// StringMatcherRegex creates a regex string matcher for regex.
+func StringMatcherRegex(regex string) *matcherpb.StringMatcher {
+	return &matcherpb.StringMatcher{
+		MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+			SafeRegex: &matcherpb.RegexMatcher{
+				EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+				},
+				Regex: regex,
+			},
+		},
+	}
+}
+
+// StringMatcherWithPrefix creates a string matcher for v with the extra prefix inserted to the
+// created string matcher, note the prefix is ignored if v is wildcard ("*").
+// The wildcard "*" will be generated as ".+" instead of ".*".
+func StringMatcherWithPrefix(v, prefix string) *matcherpb.StringMatcher {
+	switch {
+	// Check if v is "*" first to make sure we won't generate an empty prefix/suffix StringMatcher,
+	// the Envoy StringMatcher doesn't allow empty prefix/suffix.
+	case v == "*":
+		return StringMatcherRegex(".+")
+	case strings.HasPrefix(v, "*"):
+		if prefix == "" {
+			return &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Suffix{
+					Suffix: strings.TrimPrefix(v, "*"),
+				},
+			}
+		}
+		return StringMatcherRegex(prefix + ".*" + strings.TrimPrefix(v, "*"))
+	case strings.HasSuffix(v, "*"):
+		return &matcherpb.StringMatcher{
+			MatchPattern: &matcherpb.StringMatcher_Prefix{
+				Prefix: prefix + strings.TrimSuffix(v, "*"),
+			},
+		}
+	default:
+		return &matcherpb.StringMatcher{
+			MatchPattern: &matcherpb.StringMatcher_Exact{
+				Exact: prefix + v,
+			},
+		}
+	}
+}

--- a/plugin/dubbo/authz/matcher/string_test.go
+++ b/plugin/dubbo/authz/matcher/string_test.go
@@ -1,0 +1,127 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+type testCase struct {
+	name   string
+	v      string
+	prefix string
+	want   *matcherpb.StringMatcher
+}
+
+func TestStringMatcherWithPrefix(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:   "wildcardAsRequired",
+			v:      "*",
+			prefix: "abc",
+			want:   StringMatcherRegex(".+"),
+		},
+		{
+			name:   "prefix",
+			v:      "-prefix-*",
+			prefix: "abc",
+			want: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Prefix{
+					Prefix: "abc-prefix-",
+				},
+			},
+		},
+		{
+			name:   "suffix-empty-prefix",
+			v:      "*-suffix",
+			prefix: "",
+			want: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Suffix{
+					Suffix: "-suffix",
+				},
+			},
+		},
+		{
+			name:   "suffix",
+			v:      "*-suffix",
+			prefix: "abc",
+			want:   StringMatcherRegex("abc.*-suffix"),
+		},
+		{
+			name:   "exact",
+			v:      "-exact",
+			prefix: "abc",
+			want: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_Exact{
+					Exact: "abc-exact",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := StringMatcherWithPrefix(tc.v, tc.prefix)
+			if !cmp.Equal(actual, tc.want, protocmp.Transform()) {
+				t.Errorf("want %s but got %s", tc.want.String(), actual.String())
+			}
+		})
+	}
+}
+
+func TestStringMatcherRegex(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "wildcardAsRequired",
+			v:    "*",
+			want: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &matcherpb.RegexMatcher{
+						Regex: "*",
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "regexExpression",
+			v:    "+?",
+			want: &matcherpb.StringMatcher{
+				MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &matcherpb.RegexMatcher{
+						Regex: "+?",
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := StringMatcherRegex(tc.v); !cmp.Equal(actual, tc.want, protocmp.Transform()) {
+				t.Errorf("want %s but got %s", tc.want.String(), actual.String())
+			}
+		})
+	}
+}

--- a/plugin/dubbo/authz/model/generator.go
+++ b/plugin/dubbo/authz/model/generator.go
@@ -1,0 +1,80 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+
+	"github.com/aeraki-framework/aeraki/plugin/dubbo/authz/matcher"
+	"istio.io/istio/pkg/spiffe"
+)
+
+type generator interface {
+	permission(key, value string) (*rbacpb.Permission, error)
+	principal(key, value string) (*rbacpb.Principal, error)
+}
+
+type interfaceGenerator struct {
+}
+
+func (interfaceGenerator) permission(_, value string) (*rbacpb.Permission, error) {
+	m := matcher.MetadataStringMatcher("envoy.filters.dubbo.rbac", "service", matcher.StringMatcher(value))
+	return permissionMetadata(m), nil
+}
+
+func (interfaceGenerator) principal(_, _ string) (*rbacpb.Principal, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+type methodGenerator struct {
+}
+
+func (methodGenerator) permission(_, value string) (*rbacpb.Permission, error) {
+	m := matcher.MetadataStringMatcher("envoy.filters.dubbo.rbac", "method", matcher.StringMatcher(value))
+	return permissionMetadata(m), nil
+}
+
+func (methodGenerator) principal(_, _ string) (*rbacpb.Principal, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+type srcNamespaceGenerator struct {
+}
+
+func (srcNamespaceGenerator) permission(_, _ string) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (srcNamespaceGenerator) principal(_, value string) (*rbacpb.Principal, error) {
+	v := strings.Replace(value, "*", ".*", -1)
+	m := matcher.StringMatcherRegex(fmt.Sprintf(".*/ns/%s/.*", v))
+	return principalAuthenticated(m), nil
+
+}
+
+type srcPrincipalGenerator struct {
+}
+
+func (srcPrincipalGenerator) permission(_, _ string) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (srcPrincipalGenerator) principal(key, value string) (*rbacpb.Principal, error) {
+	m := matcher.StringMatcherWithPrefix(value, spiffe.URIPrefix)
+	return principalAuthenticated(m), nil
+}

--- a/plugin/dubbo/authz/model/model.go
+++ b/plugin/dubbo/authz/model/model.go
@@ -1,0 +1,264 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+
+	dubbopb "github.com/aeraki-framework/aeraki/api/dubbo/v1alpha1"
+	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+
+	"istio.io/istio/pilot/pkg/security/trustdomain"
+)
+
+const (
+	// RBACDUBBOFilterName is the name of the dubbo rbac filter
+	RBACDUBBOFilterName = "envoy.filters.dubbo.rbac"
+	// RBACDubboFilterStatPrefix is the stat prefix for dubbo rbac filter
+	RBACDubboFilterStatPrefix = "dubbo."
+
+	attrSrcNamespace = "source.namespace" // e.g. "default".
+	attrSrcPrincipal = "source.principal" // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+
+	// Internal names used to generate corresponding Envoy matcher.
+	dubboInterface = "dubboInterface"
+	dubboMethod    = "dubboMethod"
+)
+
+type rule struct {
+	key       string
+	values    []string
+	notValues []string
+	g         generator
+}
+
+type ruleList struct {
+	rules []*rule
+}
+
+// Model represents a single rule from an authorization policy. The conditions of the rule are consolidated into
+// permission or principal to align with the Envoy RBAC filter API.
+type Model struct {
+	permissions []ruleList
+	principals  []ruleList
+}
+
+// New returns a model representing a single authorization policy.
+func New(r *dubbopb.Rule) (*Model, error) {
+	m := Model{}
+
+	basePermission := ruleList{}
+	basePrincipal := ruleList{}
+
+	for _, from := range r.From {
+		merged := basePrincipal.copy()
+		if s := from.Source; s != nil {
+			merged.insertFront(srcNamespaceGenerator{}, attrSrcNamespace, s.Namespaces, s.NotNamespaces)
+			merged.insertFront(srcPrincipalGenerator{}, attrSrcPrincipal, s.Principals, s.NotPrincipals)
+		}
+		m.principals = append(m.principals, merged)
+	}
+	if len(r.From) == 0 {
+		m.principals = append(m.principals, basePrincipal)
+	}
+
+	for _, to := range r.To {
+		merged := basePermission.copy()
+		if o := to.Operation; o != nil {
+			merged.insertFront(interfaceGenerator{}, dubboInterface, o.Interfaces, o.NotInterfaces)
+			merged.insertFront(methodGenerator{}, dubboMethod, o.Methods, o.NotMethods)
+		}
+		m.permissions = append(m.permissions, merged)
+	}
+	if len(r.To) == 0 {
+		m.permissions = append(m.permissions, basePermission)
+	}
+
+	return &m, nil
+}
+
+// MigrateTrustDomain replaces the trust domain in source principal based on the trust domain aliases information.
+func (m *Model) MigrateTrustDomain(tdBundle trustdomain.Bundle) {
+	for _, p := range m.principals {
+		for _, r := range p.rules {
+			if r.key == attrSrcPrincipal {
+				if len(r.values) != 0 {
+					r.values = tdBundle.ReplaceTrustDomainAliases(r.values)
+				}
+				if len(r.notValues) != 0 {
+					r.notValues = tdBundle.ReplaceTrustDomainAliases(r.notValues)
+				}
+			}
+		}
+	}
+}
+
+// Generate generates the Envoy RBAC config from the model.
+func (m Model) Generate(action rbacpb.RBAC_Action) (*rbacpb.Policy, error) {
+	var permissions []*rbacpb.Permission
+	for _, rl := range m.permissions {
+		permission, err := generatePermission(rl, action)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, permission)
+	}
+	if len(permissions) == 0 {
+		return nil, fmt.Errorf("must have at least 1 permission")
+	}
+
+	var principals []*rbacpb.Principal
+	for _, rl := range m.principals {
+		principal, err := generatePrincipal(rl, action)
+		if err != nil {
+			return nil, err
+		}
+		principals = append(principals, principal)
+	}
+	if len(principals) == 0 {
+		return nil, fmt.Errorf("must have at least 1 principal")
+	}
+
+	return &rbacpb.Policy{
+		Permissions: permissions,
+		Principals:  principals,
+	}, nil
+}
+
+func generatePermission(rl ruleList, action rbacpb.RBAC_Action) (*rbacpb.Permission, error) {
+	var and []*rbacpb.Permission
+	for _, r := range rl.rules {
+		ret, err := r.permission(action)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, ret...)
+	}
+	if len(and) == 0 {
+		and = append(and, permissionAny())
+	}
+	return permissionAnd(and), nil
+}
+
+func generatePrincipal(rl ruleList, action rbacpb.RBAC_Action) (*rbacpb.Principal, error) {
+	var and []*rbacpb.Principal
+	for _, r := range rl.rules {
+		ret, err := r.principal(action)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, ret...)
+	}
+	if len(and) == 0 {
+		and = append(and, principalAny())
+	}
+	return principalAnd(and), nil
+}
+
+func (r rule) permission(action rbacpb.RBAC_Action) ([]*rbacpb.Permission, error) {
+	var permissions []*rbacpb.Permission
+	var or []*rbacpb.Permission
+	for _, value := range r.values {
+		p, err := r.g.permission(r.key, value)
+		if err := r.checkError(action, err); err != nil {
+			return nil, err
+		}
+		if p != nil {
+			or = append(or, p)
+		}
+	}
+	if len(or) > 0 {
+		permissions = append(permissions, permissionOr(or))
+	}
+
+	or = nil
+	for _, notValue := range r.notValues {
+		p, err := r.g.permission(r.key, notValue)
+		if err := r.checkError(action, err); err != nil {
+			return nil, err
+		}
+		if p != nil {
+			or = append(or, p)
+		}
+	}
+	if len(or) > 0 {
+		permissions = append(permissions, permissionNot(permissionOr(or)))
+	}
+	return permissions, nil
+}
+
+func (r rule) principal(action rbacpb.RBAC_Action) ([]*rbacpb.Principal, error) {
+	var principals []*rbacpb.Principal
+	var or []*rbacpb.Principal
+	for _, value := range r.values {
+		p, err := r.g.principal(r.key, value)
+		if err := r.checkError(action, err); err != nil {
+			return nil, err
+		}
+		if p != nil {
+			or = append(or, p)
+		}
+	}
+	if len(or) > 0 {
+		principals = append(principals, principalOr(or))
+	}
+
+	or = nil
+	for _, notValue := range r.notValues {
+		p, err := r.g.principal(r.key, notValue)
+		if err := r.checkError(action, err); err != nil {
+			return nil, err
+		}
+		if p != nil {
+			or = append(or, p)
+		}
+	}
+	if len(or) > 0 {
+		principals = append(principals, principalNot(principalOr(or)))
+	}
+	return principals, nil
+}
+
+func (r rule) checkError(action rbacpb.RBAC_Action, err error) error {
+	if action == rbacpb.RBAC_ALLOW {
+		// Return the error as-is for allow policy. This will make all rules in the current permission ignored, effectively
+		// result in a smaller allow policy (i.e. less likely to allow a request).
+		return err
+	}
+
+	// Ignore the error for a deny or audit policy. This will make the current rule ignored and continue the generation of
+	// the next rule, effectively resulting in a wider deny or audit policy (i.e. more likely to deny or audit a request).
+	return nil
+}
+
+func (p *ruleList) copy() ruleList {
+	r := ruleList{}
+	r.rules = append([]*rule{}, p.rules...)
+	return r
+}
+
+func (p *ruleList) insertFront(g generator, key string, values, notValues []string) {
+	if len(values) == 0 && len(notValues) == 0 {
+		return
+	}
+	r := &rule{
+		key:       key,
+		values:    values,
+		notValues: notValues,
+		g:         g,
+	}
+
+	p.rules = append([]*rule{r}, p.rules...)
+}

--- a/plugin/dubbo/authz/model/permission.go
+++ b/plugin/dubbo/authz/model/permission.go
@@ -1,0 +1,64 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+func permissionAny() *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_Any{
+			Any: true,
+		},
+	}
+}
+
+func permissionAnd(permission []*rbacpb.Permission) *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_AndRules{
+			AndRules: &rbacpb.Permission_Set{
+				Rules: permission,
+			},
+		},
+	}
+}
+
+func permissionOr(permission []*rbacpb.Permission) *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_OrRules{
+			OrRules: &rbacpb.Permission_Set{
+				Rules: permission,
+			},
+		},
+	}
+}
+
+func permissionNot(permission *rbacpb.Permission) *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_NotRule{
+			NotRule: permission,
+		},
+	}
+}
+
+func permissionMetadata(metadata *matcherpb.MetadataMatcher) *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_Metadata{
+			Metadata: metadata,
+		},
+	}
+}

--- a/plugin/dubbo/authz/model/principal.go
+++ b/plugin/dubbo/authz/model/principal.go
@@ -1,0 +1,66 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+func principalAny() *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_Any{
+			Any: true,
+		},
+	}
+}
+
+func principalOr(principals []*rbacpb.Principal) *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_OrIds{
+			OrIds: &rbacpb.Principal_Set{
+				Ids: principals,
+			},
+		},
+	}
+}
+
+func principalAnd(principals []*rbacpb.Principal) *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_AndIds{
+			AndIds: &rbacpb.Principal_Set{
+				Ids: principals,
+			},
+		},
+	}
+}
+
+func principalNot(principal *rbacpb.Principal) *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_NotId{
+			NotId: principal,
+		},
+	}
+}
+
+func principalAuthenticated(name *matcherpb.StringMatcher) *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_Authenticated_{
+			Authenticated: &rbacpb.Principal_Authenticated{
+				PrincipalName: name,
+			},
+		},
+	}
+}

--- a/test/e2e/common/aeraki.yaml
+++ b/test/e2e/common/aeraki.yaml
@@ -99,6 +99,18 @@ rules:
       - create
       - delete
   - apiGroups:
+      - dubbo.aeraki.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
       - networking.istio.io
     resources:
       - virtualservices

--- a/test/e2e/dubbo/dubbo_test.go
+++ b/test/e2e/dubbo/dubbo_test.go
@@ -52,7 +52,7 @@ func TestSidecarOutboundConfig(t *testing.T) {
 	consumerPod, _ := util.GetPodName("dubbo", "app=dubbo-sample-consumer", "")
 	config, _ := util.PodExec("dubbo", consumerPod, "istio-proxy", "curl -s 127.0.0.1:15000/config_dump", false, "")
 	config = strings.Join(strings.Fields(config), "")
-	want := "{\n\"name\":\"envoy.filters.network.dubbo_proxy\",\n\"typed_config\":{\n\"@type\":\"type.googleapis.com/envoy.extensions.filters.network.dubbo_proxy.v3.DubboProxy\",\n\"stat_prefix\":\"outbound|20880||org.apache.dubbo.samples.basic.api.demoservice\",\n\"route_config\":[\n{\n\"name\":\"outbound|20880||org.apache.dubbo.samples.basic.api.demoservice\",\n\"interface\":\"org.apache.dubbo.samples.basic.api.DemoService\",\n\"routes\":[\n{\n\"match\":{\n\"method\":{\n\"name\":{\n\"safe_regex\":{\n\"google_re2\":{},\n\"regex\":\".*\"\n}\n}\n}\n},\n\"route\":{\n\"cluster\":\"outbound|20880||org.apache.dubbo.samples.basic.api.demoservice\"\n}\n}\n]\n}\n]\n}\n}\n]\n}"
+	want := "{\n \"name\": \"envoy.filters.network.dubbo_proxy\",\n \"typed_config\": {\n\"@type\": \"type.googleapis.com/envoy.extensions.filters.network.dubbo_proxy.v3.DubboProxy\",\n\"stat_prefix\": \"outbound|20880||org.apache.dubbo.samples.basic.api.testservice\",\n\"route_config\": [\n {\n\"name\": \"outbound|20880||org.apache.dubbo.samples.basic.api.testservice\",\n\"interface\": \"org.apache.dubbo.samples.basic.api.TestService\",\n\"routes\": [\n {\n\"match\": {\n \"method\": {\n\"name\": {\n \"safe_regex\": {\n\"google_re2\": {},\n\"regex\": \".*\"\n }\n}\n }\n},\n\"route\": {\n \"cluster\": \"outbound|20880||org.apache.dubbo.samples.basic.api.testservice\"\n}\n }\n]\n }\n],\n\"dubbo_filters\": [\n {\n\"name\": \"envoy.filters.dubbo.router\"\n }\n]\n }\n}\n ]\n}"
 	want = strings.Join(strings.Fields(want), "")
 	if !strings.Contains(config, want) {
 		t.Errorf("cant't find dubbo proxy in the outbound listener of the envoy sidecar: conf \n %s, want \n %s", config, want)
@@ -65,8 +65,7 @@ func TestSidecarInboundConfig(t *testing.T) {
 	providerPod, _ := util.GetPodName("dubbo", "app=dubbo-sample-provider", "")
 	config, _ := util.PodExec("dubbo", providerPod, "istio-proxy", "curl -s 127.0.0.1:15000/config_dump", false, "")
 	config = strings.Join(strings.Fields(config), "")
-	want := "{\n\"name\":\"envoy.filters.network.dubbo_proxy\",\n\"typed_config\":{\n\"@type\":\"type.googleapis." +
-		"com/envoy.extensions.filters.network.dubbo_proxy.v3.DubboProxy\",\n\"stat_prefix\":\"inbound|20880||\",\n\"route_config\":[\n{\n\"name\":\"inbound|20880||\",\n\"interface\":\"*\",\n\"routes\":[\n{\n\"match\":{\n\"method\":{\n\"name\":{\n\"safe_regex\":{\n\"google_re2\":{},\n\"regex\":\".*\"\n}\n}\n}\n},\n\"route\":{\n\"cluster\":\"inbound|20880||\"\n}\n}\n]\n}\n]\n}\n}"
+	want := "{\n\"name\":\"envoy.filters.network.dubbo_proxy\",\n\"typed_config\":{\n\"@type\":\"type.googleapis.com/envoy.extensions.filters.network.dubbo_proxy.v3.DubboProxy\",\n\"stat_prefix\":\"inbound|20880||\",\n\"route_config\":[\n{\n\"name\":\"inbound|20880||\",\n\"interface\":\"*\",\n\"routes\":[\n{\n\"match\":{\n\"method\":{\n\"name\":{\n\"safe_regex\":{\n\"google_re2\":{},\n\"regex\":\".*\"\n}\n}\n}\n},\n\"route\":{\n\"cluster\":\"inbound|20880||\"\n}\n}\n]\n}\n],\n\"dubbo_filters\":[\n{\n\"name\":\"envoy.filters.dubbo.router\"\n}\n]\n}\n}"
 	want = strings.Join(strings.Fields(want), "")
 	if !strings.Contains(config, want) {
 		t.Errorf("cant't find dubbo proxy in the inbound listener of the envoy sidecar: conf \n %s, want \n %s", config, want)


### PR DESCRIPTION
Support peer authorization on interfaces and methods.

Example:
```yaml
apiVersion: dubbo.aeraki.io/v1alpha1
kind: DubboAuthorizationPolicy
metadata:
  name: dubbo-demo
  namespace: dubbo
spec:
  action: ALLOW
  rules:
  - from:
    - source:
        principals: ["cluster.local/ns/dubbo/sa/dubbo-consumer"]
    to:
    - operation:
        interfaces: ["org.apache.dubbo.samples.basic.api.DemoService"]
        methods: ["sayHello"]
```