### PR TITLE
bugfix: Bad yaml format cause traffic management fail.

### DIFF
--- a/demo/metaprotocol-dubbo/metarouter-v1.yaml
+++ b/demo/metaprotocol-dubbo/metarouter-v1.yaml
@@ -8,7 +8,7 @@ spec:
     - org.apache.dubbo.samples.basic.api.demoservice
   routes:
     - name: v1
-    - match:
+      match:
         attributes:
           method:
             exact: sayHello


### PR DESCRIPTION
in demo/metaprotocol-dubbo. There's mistake about bad yaml format in "metarouter-v1.yaml" cause traffic management fail. 