### PR TITLE
ci(aeraki,lazyxds): support auto build and push docker image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+# Auto build and push docker image to docker hub when releasing tags
+
+name: Auto Build and Push image
+
+on:
+  create
+
+jobs:
+  publish_image:
+    name: Build and Push aeraki image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.5
+        with:
+          submodules: recursive
+
+      - name: Extract Tags name
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        id: tag_env
+        shell: bash
+        run: |
+          echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+
+      - name: Extract Tags Type
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        id: tag_type
+        shell: bash
+        run: |
+          echo "##[set-output name=version;]$(echo ${GITHUB_REF#refs/tags/})"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Aeraki Docker Image
+        if: ${{ startsWith(steps.tag_type.outputs.version, 'aeraki/') }}
+        run: |
+          make docker-build tag=${{ steps.tag_env.outputs.version }}
+
+      - name: Build LazyXDS Docker Image
+        if: ${{ startsWith(steps.tag_type.outputs.version, 'lazyxds/') }}
+        run: |
+          make docker-build.lazyxds tag=${{ steps.tag_env.outputs.version }}
+      
+      - name: Push Aeraki Docker image
+        if: ${{ startsWith(steps.tag_type.outputs.version, 'aeraki/') }}
+        run: |
+          docker push aeraki/aeraki:${{ steps.tag_env.outputs.version }}
+
+      - name: Push LazyXDS Docker image
+        if: ${{ startsWith(steps.tag_type.outputs.version, 'lazyxds/') }}
+        run: |
+          docker push aeraki/lazyxds:${{ steps.tag_env.outputs.version }}

--- a/demo/thrift/uninstall.sh
+++ b/demo/thrift/uninstall.sh
@@ -1,7 +1,6 @@
 BASEDIR=$(dirname "$0")
 
-kubectl delete -f $BASEDIR/dubbo-sample.yaml -n dubbo
-kubectl delete -f $BASEDIR/serviceentry.yaml -n dubbo
-kubectl delete -f $BASEDIR/destinationrule.yaml -n dubbo
-kubectl delete -f $BASEDIR/virtualservice-traffic-splitting.yaml -n dubbo
-kubectl delete ns dubbo
+kubectl delete -f $BASEDIR/thrift-sample.yaml -n thrift
+kubectl delete -f $BASEDIR/destinationrule.yaml -n thrift
+kubectl delete -f $BASEDIR/virtualservice-traffic-splitting.yaml -n thrift
+kubectl delete ns thrift

--- a/plugin/redis/generator.go
+++ b/plugin/redis/generator.go
@@ -56,7 +56,7 @@ type Generator struct {
 }
 
 var (
-	// Timeout is the default timeout for list object from apiserver
+	// Timeout is the default timeout for listing object from apiserver
 	Timeout = time.Second * 10
 )
 


### PR DESCRIPTION
feat: Support auto build and push docker image when releasing.

This ci only will be triggered by creating tags.

When creating tags like these format, this workflow will start to work:
+ ` aeraki/{version}`
+ ` lazyxds/{version}`

For example, if we create a tag named `aeraki/v0.1.1`, ci will auto build and publish a image called `aeraki/aeraki:v0.1.1` to hub.

And if we create a tag named `lazyxds/v0.1.2`, ci will auto build and publish a image called `aeraki/lazyxds:v0.1.2` to hub.

> + We need to set two secrets in GitHub Secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
> + This PR will work fine after merging this #117 PR
