### PR TITLE
support discovery selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,4 +51,5 @@ require (
 	k8s.io/component-base v0.22.0
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.9.5
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/lazyxds/pkg/controller/discovery_selector.go
+++ b/lazyxds/pkg/controller/discovery_selector.go
@@ -1,0 +1,36 @@
+// Copyright Aeraki Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (c *AggregationController) updateDiscoverySelector(discoverySelector []*metav1.LabelSelector) error {
+	var selectors []labels.Selector
+	// convert LabelSelectors to Selectors
+	for _, selector := range discoverySelector {
+		ls, err := metav1.LabelSelectorAsSelector(selector)
+		if err != nil {
+			c.log.Error(err, "error initializing discovery namespaces filter, invalid discovery selector: %v")
+			return err
+		}
+		selectors = append(selectors, ls)
+	}
+
+	c.selectors = selectors
+	return nil
+}

--- a/lazyxds/pkg/controller/discoveryselector/controller.go
+++ b/lazyxds/pkg/controller/discoveryselector/controller.go
@@ -1,0 +1,102 @@
+// Copyright Aeraki Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryselector
+
+import (
+	"context"
+	"github.com/aeraki-framework/aeraki/lazyxds/pkg/utils/log"
+	"github.com/go-logr/logr"
+	meshv1alpha1 "istio.io/api/mesh/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/yaml"
+	"time"
+)
+
+// Controller is responsible for watching discoverySelectors
+type Controller struct {
+	log                     logr.Logger
+	clientset               *kubernetes.Clientset
+	updateDiscoverySelector func([]*metav1.LabelSelector) error
+	reconcileAllNamespaces  func(context.Context) error
+}
+
+// NewController creates a new service controller
+func NewController(
+	clientset *kubernetes.Clientset,
+	updateDiscoverySelector func([]*metav1.LabelSelector) error,
+	reconcileAllNamespaces func(context.Context) error,
+) *Controller {
+	logger := klogr.New().WithName("ConfigMapController")
+	c := &Controller{
+		log:                     logger,
+		clientset:               clientset,
+		updateDiscoverySelector: updateDiscoverySelector,
+		reconcileAllNamespaces:  reconcileAllNamespaces,
+	}
+
+	return c
+}
+
+// Run begins watching and syncing.
+func (c *Controller) Run(stopCh <-chan struct{}) {
+	c.log.Info("starting discoveryselector controller...")
+	ctx := log.WithContext(context.Background(), c.log)
+	configMapWatcher, err := c.clientset.CoreV1().ConfigMaps("istio-system").Watch(ctx, metav1.ListOptions{
+		LabelSelector: "release=istio",
+	})
+	if err != nil {
+		c.log.Error(err, "watch configMap <istio> failed")
+		return
+	}
+	for {
+		select {
+		case e, ok := <-configMapWatcher.ResultChan():
+			if !ok {
+				c.log.Info("configMapWatcher chan has been close!")
+				c.log.Info("clean chan over!")
+				time.Sleep(time.Second * 5)
+			}
+			if e.Object != nil {
+				c.log.Info("configMapWatcher chan is ok")
+				dataMap := e.Object.DeepCopyObject().(*corev1.ConfigMap).Data
+				if _, ok := dataMap["mesh"]; !ok {
+					break
+				}
+				meshconfig := meshv1alpha1.MeshConfig{}
+				err := yaml.Unmarshal([]byte(dataMap["mesh"]), &meshconfig)
+				if err != nil {
+					c.log.Error(err, "deserialize meshconfig failed")
+					break
+				}
+				c.log.Info("meshconfig.DiscoverySelectors modified", "matchLabels", meshconfig.DiscoverySelectors)
+				err = c.updateDiscoverySelector(meshconfig.DiscoverySelectors)
+				if err != nil {
+					c.log.Error(err, "update DiscoverySelector error")
+					break
+				}
+				err = c.reconcileAllNamespaces(ctx)
+				if err != nil {
+					c.log.Error(err, "reconcileAllNamespaces error")
+				}
+			}
+		case <-stopCh:
+			c.log.Info("close configMapWatcher")
+			return
+		}
+	}
+}

--- a/lazyxds/pkg/controller/namespace.go
+++ b/lazyxds/pkg/controller/namespace.go
@@ -52,19 +52,15 @@ func (c *AggregationController) deleteNamespace(ctx context.Context, clusterName
 
 	return c.reconcileNamespace(ctx, ns)
 }
+
+// reconcileAllNamespace do this when namespace labels updated
 func (c *AggregationController) reconcileNamespace(ctx context.Context, ns *model.Namespace) (err error) {
-	c.services.Range(func(key, value interface{}) bool {
-		svc := value.(*model.Service)
-		if svc.Namespace != ns.Name {
-			return true
-		}
+	c.serviceController.ReconcileServices(ns)
+	return c.reconcileAllLazyServices(ctx)
+}
 
-		e := c.tryReconcileLazyService(ctx, svc)
-		if e != nil {
-			err = e
-		}
-		return true
-	})
-
-	return
+// reconcileAllNamespace do this when discoverySelector updated
+func (c *AggregationController) reconcileAllNamespaces(ctx context.Context) (err error) {
+	c.serviceController.ReconcileAllServices()
+	return c.reconcileAllLazyServices(ctx)
 }

--- a/lazyxds/pkg/controller/namespace/controller.go
+++ b/lazyxds/pkg/controller/namespace/controller.go
@@ -93,7 +93,7 @@ func (c *Controller) update(oldObj, curObj interface{}) {
 }
 
 func (c *Controller) needsUpdate(old *corev1.Namespace, new *corev1.Namespace) bool {
-	return !reflect.DeepEqual(old.Annotations, new.Annotations) || new.GetDeletionTimestamp() != nil
+	return !reflect.DeepEqual(old.Annotations, new.Annotations) || !reflect.DeepEqual(old.Labels, new.Labels) || new.GetDeletionTimestamp() != nil
 }
 
 func (c *Controller) delete(obj interface{}) {

--- a/lazyxds/pkg/controller/service/controller.go
+++ b/lazyxds/pkg/controller/service/controller.go
@@ -17,6 +17,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"github.com/aeraki-framework/aeraki/lazyxds/pkg/model"
+	"k8s.io/apimachinery/pkg/labels"
 	"reflect"
 	"time"
 
@@ -77,6 +79,26 @@ func NewController(
 	})
 
 	return c
+}
+
+// ReconcileAllServices reconcile all the services
+func (c *Controller) ReconcileAllServices() {
+	services, _ := c.lister.List(labels.Everything())
+	for _, service := range services {
+		c.log.V(4).Info("Adding Service", "name", service.Name)
+		c.enqueue(service)
+	}
+}
+
+// ReconcileServices reconcile services in a certain namespace
+func (c *Controller) ReconcileServices(ns *model.Namespace) {
+	services, _ := c.lister.List(labels.Everything())
+	for _, service := range services {
+		if service.Namespace == ns.Name {
+			c.log.V(4).Info("Adding Service", "name", service.Name)
+			c.enqueue(service)
+		}
+	}
 }
 
 func (c *Controller) add(obj interface{}) {

--- a/lazyxds/pkg/manager/manager.go
+++ b/lazyxds/pkg/manager/manager.go
@@ -69,7 +69,7 @@ func NewManager(conf *config.Config, stop <-chan struct{}) (*Manager, error) {
 		stop:         stop,
 		masterClient: kubeClient,
 		istioClient:  istioClient,
-		controller:   controller.NewController(istioClient, stop),
+		controller:   controller.NewController(istioClient, kubeClient, stop),
 	}
 	singleton.accessLogServer = accesslog.NewAccessLogServer(singleton.controller)
 

--- a/lazyxds/pkg/model/namespace.go
+++ b/lazyxds/pkg/model/namespace.go
@@ -38,6 +38,8 @@ type Namespace struct {
 	Distribution map[string]bool
 	UserSidecar  map[string]struct{}
 
+	Labels map[string]string
+
 	LazyStatus NSLazyStatus
 }
 
@@ -47,6 +49,7 @@ func NewNamespace(namespace *corev1.Namespace) *Namespace {
 		Name:         namespace.Name,
 		Distribution: make(map[string]bool),
 		UserSidecar:  make(map[string]struct{}),
+		Labels:       namespace.Labels,
 	}
 }
 
@@ -68,6 +71,7 @@ func (ns *Namespace) LazyEnabled(clusterName string) bool {
 // Update update one namespace of the multiCluster
 func (ns *Namespace) Update(clusterName string, namespace *corev1.Namespace) {
 	ns.Distribution[clusterName] = utils.IsLazyEnabled(namespace.Annotations)
+	ns.Labels = namespace.Labels
 	ns.updateLazyStatus()
 }
 

--- a/lazyxds/pkg/model/service.go
+++ b/lazyxds/pkg/model/service.go
@@ -182,9 +182,8 @@ func (svc *Service) updateSpec() {
 				spec.LazyEnabled = false
 			} else if svc.NSLazy == NSLazyStatusEnabled {
 				spec.LazyEnabled = true
-			} else {
-				spec.LazyEnabled = spec.LazyEnabled || cs.LazyEnabled
 			}
+			spec.LazyEnabled = spec.LazyEnabled || cs.LazyEnabled
 		}
 
 		// if cs.LazyEnabled {


### PR DESCRIPTION
### What this PR does / Why we need it:
1. Ignore the services in those namespaces which do not match the istio discovery selector, so that these services won't be configured in  the envoyFilter of lazy service.
2. Watch the  changes of discovery selector, refresh all the lazy service's crds created by lazyxds before.


* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added related test cases?
* [ ] Have you modified the related document?
* [ ] Is this PR backward compatible? 