### PR TITLE
update the ListOptions of discoverySelector watcher from metadata.Labels to matadata.name

### DIFF
--- a/lazyxds/pkg/controller/aggregation.go
+++ b/lazyxds/pkg/controller/aggregation.go
@@ -72,7 +72,7 @@ type AggregationController struct {
 	// all lazy services
 	lazyServices map[string]*model.Service
 	// istio discovery namespace selector
-	selectors []labels.Selector
+	discoverySelectors []labels.Selector
 
 	namespaces sync.Map
 	endpoints  sync.Map

--- a/lazyxds/pkg/controller/discovery_selector.go
+++ b/lazyxds/pkg/controller/discovery_selector.go
@@ -31,6 +31,6 @@ func (c *AggregationController) updateDiscoverySelector(discoverySelector []*met
 		selectors = append(selectors, ls)
 	}
 
-	c.selectors = selectors
+	c.discoverySelectors = selectors
 	return nil
 }

--- a/lazyxds/pkg/controller/discoveryselector/controller.go
+++ b/lazyxds/pkg/controller/discoveryselector/controller.go
@@ -57,7 +57,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	c.log.Info("starting discoveryselector controller...")
 	ctx := log.WithContext(context.Background(), c.log)
 	configMapWatcher, err := c.clientset.CoreV1().ConfigMaps("istio-system").Watch(ctx, metav1.ListOptions{
-		LabelSelector: "release=istio",
+		FieldSelector: "metadata.name=istio",
 	})
 	if err != nil {
 		c.log.Error(err, "watch configMap <istio> failed")

--- a/lazyxds/pkg/controller/service.go
+++ b/lazyxds/pkg/controller/service.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (c *AggregationController) syncService(ctx context.Context, clusterName string, service *corev1.Service) (err error) {
-	selectors := c.selectors
+	selectors := c.discoverySelectors
 	id := utils.FQDN(service.Name, service.Namespace)
 
 	matched, err := c.matchDiscoverySelector(selectors, service)

--- a/lazyxds/pkg/model/service.go
+++ b/lazyxds/pkg/model/service.go
@@ -182,8 +182,9 @@ func (svc *Service) updateSpec() {
 				spec.LazyEnabled = false
 			} else if svc.NSLazy == NSLazyStatusEnabled {
 				spec.LazyEnabled = true
+			} else {
+				spec.LazyEnabled = spec.LazyEnabled || cs.LazyEnabled
 			}
-			spec.LazyEnabled = spec.LazyEnabled || cs.LazyEnabled
 		}
 
 		// if cs.LazyEnabled {


### PR DESCRIPTION
1.update the ListOptions of discoverySelector watcher from metadata.Labels to matadata.name
2.optimize variable name